### PR TITLE
Fix detection of path conflicts.

### DIFF
--- a/test/local/test_multiproject_functions.py
+++ b/test/local/test_multiproject_functions.py
@@ -143,7 +143,7 @@ class FunctionsTest(unittest.TestCase):
         self.assertEqual(None, realpath_relation("/foo", "/bar"))
         self.assertEqual(None, realpath_relation("/foo", "/foo2"))
         self.assertEqual(None, realpath_relation("/foo/bar", "/foo/ba"))
-        self.assertEqual(None, realpath_relation("/foo", "/foobar"))
+        self.assertEqual(None, realpath_relation("/foo/ba", "/foo/bar/baz"))
         self.assertEqual(None, realpath_relation("/foo/bar/baz", "/foo/ba"))
 
     def test_select_element(self):


### PR DESCRIPTION
- os.path.commonprefix does not work as expected to return
  path component prefixes, but rather works on character
  by character basis.

A real example of a .rosinstall file (generated by rosinstall_generator) for which init failes without this patch:

```
- tar:
    local-name: libuvc
    uri: https://github.com/ktossell/libuvc-release/archive/release/hydro/libuvc/0.0.4-1.tar.gz
    version: libuvc-release-release-hydro-libuvc-0.0.4-1
- tar:
    local-name: libuvc_ros/libuvc_camera
    uri: https://github.com/ktossell/libuvc_ros-release/archive/release/hydro/libuvc_camera/0.0.7-0.tar.gz
    version: libuvc_ros-release-release-hydro-libuvc_camera-0.0.7-0
```
