### PR TITLE
info: adding entries for unmanaged paths

### DIFF
--- a/src/wstool/cli_common.py
+++ b/src/wstool/cli_common.py
@@ -175,7 +175,6 @@ def get_info_table_elements(basepath, entries):
                 line['actualversion'] = line['actualversion'][0:12]
 
         if line['scm'] is not None:
-
             if line['scm'] == 'svn':
                 # in case of SVN, we can use the final part of
                 # standard uri as version
@@ -244,22 +243,32 @@ def get_info_table_elements(basepath, entries):
     return outputs
 
 
-def get_info_table(basepath, entries, data_only=False, reverse=False):
+def get_info_table(basepath, entries, data_only=False, reverse=False, unmanaged=False):
     """
     return a refined textual representation of the entries. Provides
     column headers and processes data.
     """
-    headers = {
-        'uri': "URI  (Spec) [http(s)://...]",
-        'scm': "SCM ",
-        'localname': "Localname",
-        'version': "Version-Spec",
-        'matching': "UID  (Spec)",
-        'status': "S"}
+    if unmanaged:
+        headers = {
+            'uri': "URI [http(s)://...]",
+            'scm': "SCM ",
+            'localname': "Localname"}
 
-    # table design
-    selected_headers = ['localname', 'status', 'scm', 'version',
-                        'matching', 'uri']
+        # table design
+        selected_headers = ['localname', 'scm', 'uri']
+    else:
+
+        headers = {
+            'uri': "URI  (Spec) [http(s)://...]",
+            'scm': "SCM ",
+            'localname': "Localname",
+            'version': "Version-Spec",
+            'matching': "UID  (Spec)",
+            'status': "S"}
+
+        # table design
+        selected_headers = ['localname', 'status', 'scm', 'version',
+                            'matching', 'uri']
 
     outputs = get_info_table_elements(
         basepath=basepath,

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -666,7 +666,7 @@ $ roslocate info robot_model | %(prog)s merge -
         :param target_path: where to look for config
         :param config: config to use instead of parsing file anew
         """
-        usage = ("usage: %s set [localname] [SCM-URI]?  [--(%ssvn|hg|git|bzr)] [--version=VERSION]]" %
+        usage = ("usage: %s set [localname] [[SCM-URI] --(%ssvn|hg|git|bzr) [--version=VERSION]?]?" %
                  (self.progname, 'detached|' if self.allow_other_element else ''))
         parser = OptionParser(
             usage=usage,
@@ -1026,6 +1026,10 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
             "-t", "--target-workspace", dest="workspace", default=None,
             help="which workspace to use",
             action="store")
+        parser.add_option(
+            "-m", "--managed-only", dest="unmanaged", default=True,
+            help="only show managed elements",
+            action="store_false")
         (options, args) = parser.parse_args(argv)
 
         if config is None:
@@ -1074,5 +1078,15 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
                                reverse=reverse)
         if table is not None and table != '':
            print("\n%s" % table)
+
+        if options.unmanaged:
+            outputs2 = multiproject_cmd.cmd_find_unmanaged_repos(config)
+            table2 = get_info_table(config.get_base_path(),
+                                   outputs2,
+                                   options.data_only,
+                                   reverse=reverse,
+                                   unmanaged=True)
+            if table2 is not None and table2 != '':
+                print("\nAlso detected these repositories in the workspace, add using '%s set':\n\n%s" % (self.progname, table2))
 
         return 0

--- a/src/wstool/multiproject_cmd.py
+++ b/src/wstool/multiproject_cmd.py
@@ -48,11 +48,17 @@ import os
 from wstool.common import MultiProjectException, DistributedWork, \
     select_elements, normabspath
 from wstool.config import Config, realpath_relation
+from wstool.config_elements import AVCSConfigElement
 from wstool.config_yaml import aggregate_from_uris, generate_config_yaml, \
     get_path_specs_from_uri, PathSpec
 
 import vcstools
 import vcstools.__version__
+from vcstools.vcs_abstraction import get_vcs_client
+from vcstools.git import GitClient
+from vcstools.hg  import HgClient
+from vcstools.bzr import BzrClient
+from vcstools.svn import SvnClient
 
 
 def get_config(basepath,
@@ -385,6 +391,9 @@ def cmd_info(config, localnames=None, untracked=False):
     """
 
     class InfoRetriever():
+        """
+        Auxilliary class to perform IO-bound operations in individual threads
+        """
 
         def __init__(self, element, path, untracked):
             self.element = element
@@ -441,13 +450,67 @@ def cmd_info(config, localnames=None, untracked=False):
                     'actualversion': actualversion,
                     'modified': modified,
                     'properties': self.element.get_properties()}
+
     path = config.get_base_path()
     # call SCM info in separate threads
     elements = config.get_config_elements()
-    work = DistributedWork(len(elements))
     elements = select_elements(config, localnames)
+    work = DistributedWork(len(elements))
     for element in elements:
         if element.get_properties() is None or not 'setup-file' in element.get_properties():
             work.add_thread(InfoRetriever(element, path, untracked))
     outputs = work.run()
+
+    return outputs
+
+
+
+def cmd_find_unmanaged_repos(config):
+    """
+    Auxilliary function to find SCM folders within workspace that have not been tracked. This
+    allows quicker diagnosis of the general state in a workspace, where folders can be part
+    of the build even when they are not mentioned in the .rosinstall file.
+    Nested SCMs are not investigated.
+    """
+
+    class UnmanagedInfoRetriever():
+
+        def __init__(self, path, localname, scm_type):
+            self.path = path
+            self.localname = localname
+            self.scm_type = scm_type
+            self.element = AVCSConfigElement(scm_type, os.path.join(self.path, self.localname), localname, '')
+
+        def do_work(self):
+            vcsc = get_vcs_client(self.scm_type, os.path.join(self.path, self.localname))
+            return {'scm': '--' + self.scm_type, # prefix '--' to allow copy&paste to set command
+                'localname': self.localname,
+                'path': self.path,
+                'uri': vcsc.get_url(),
+                'properties': self.element.get_properties()}
+
+    path = config.get_base_path()
+    # call SCM info in separate threads
+    elements = config.get_config_elements()
+
+    managed_paths = [os.path.join(path, e.get_local_name()) for e in elements]
+    unmanaged_paths = []
+    scm_clients = {SvnClient: 'svn', GitClient: 'git', BzrClient:'bzr', HgClient:'hg'}
+    for root, dirs, files in os.walk(path):
+        if root in managed_paths:
+            # remove it from the walk if it's managed
+            del dirs[:]
+        else:
+            for client, key in scm_clients.items():
+                # check if it's a vcs dir
+                if client.static_detect_presence(root):
+                    # add it to the unmanaged list
+                    unmanaged_paths.append((os.path.relpath(root, path), key))
+                    # don't walk any other directories in this root
+                    del dirs[:]
+    work = DistributedWork(len(unmanaged_paths))
+    for localname, scm_type in sorted(unmanaged_paths, key=lambda up: up[0], reverse=True):
+        work.add_thread(UnmanagedInfoRetriever(path, localname, scm_type))
+    outputs = work.run()
+
     return outputs


### PR DESCRIPTION
This patch adds a new `!` status for vcs-controlled paths which are not listed in a workspace's `.rosinstall` file. This addresses some usability requests described in #26.

Below shows the output for a workspace with three repos which aren't in the `.rosinstall` file:

```
[yavin:~/ws/hydro/main/src]$ wstool info       
workspace: /home/jbohren/ws/hydro/main/src

 Localname                                  S SCM  Version-Spec                     UID  (Spec)  URI  (Spec) [http(s)://...]
 ---------                                  - ---- ------------                     -----------  ---------------------------
 sophus                                     ! git                                   731ee8922ed3 git@github.com:jbohren-forks/sophus.git
 liburdfdom-headers-dev                     ! git                                   1593fb14d8b1 git@github.com:ros/urdfdom_headers.git
 gazebo                                     ! hg                                    e1159a7f54fe ssh://hg@bitbucket.org/osrf/gazebo
 ascent                                     ! git                                   a62449a90ae0 git@git.lcsr.jhu.edu:ascent/ascent.git
 catkin                                       git  dont-overwrite-marker-on-install 46da0c484922 git@github.com:jbohren-forks/catkin.git
 cartesian_trajectory_msgs                    git                                   9061672c8eaf git@github.com:jhu-lcsr/cartesian_trajectory_msgs.git
 barrett_moveit                               git                                   6a7f5f8ec7a3 git@github.com:jhu-lcsr/barrett_moveit.git
 barrett_model                                git                                   63670e70f9ae git@github.com:jhu-lcsr/barrett_model.git
```

This patch also adds the additional description to the cli documentation (though this documentation looks really out of date otherwise):

```
[yavin:~/ws/hydro/main/src]$ wstool info -h
Usage: wstool info [localname]* [OPTIONS]

Overview of some entries

The Status (S) column shows
 !  for not listed in the config file
 x  for missing
 L  for uncommited (local) changes
 V  for difference in version and/or remote URI

The 'Version-Spec' column shows what tag, branch or revision was given
in the .rosinstall file. The 'UID' column shows the unique ID of the
current (and specified) version. The 'URI' column shows the configured
URL of the repo.

If status is V, the difference between what was specified and what is
real is shown in the respective column. For SVN entries, the url is
split up according to standard layout (trunk/tags/branches).

When given one localname, just show the data of one element in list form.
This also has the generic properties element which is usually empty.

The --only option accepts keywords: ['path', 'localname', 'version',
'revision', 'cur_revision', 'uri', 'cur_uri', 'scmtype']

Examples:
$ wstool info -t ~/ros/fuerte
$ wstool info robot_model
$ wstool info --yaml
$ wstool info --only=path,cur_uri,cur_revision robot_model geometry


Options:
  -h, --help            show this help message and exit
  --data-only           Does not provide explanations
  --only=ONLY           Shows comma-separated lists of only given comma-
                        separated attribute(s).
  --yaml                Shows only version of single entry. Intended for
                        scripting.
  -u, --untracked       Also show untracked files as modifications
  -t WORKSPACE, --target-workspace=WORKSPACE
                        which workspace to use

See: http://www.ros.org/wiki/rosinstall for details
```
