### PR TITLE
Extend wstool info with branch data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='wstool',
       packages=['wstool'],
       package_dir={'': 'src'},
       # rosinstall dependency to be kept in order not to break ros hydro install instructions
-      install_requires=['vcstools>=0.1.34', 'pyyaml'],
+      install_requires=['vcstools>=0.1.37', 'pyyaml'],
       scripts=["scripts/wstool"],
       author="Tully Foote",
       author_email="tfoote@osrfoundation.org",

--- a/src/wstool/config_elements.py
+++ b/src/wstool/config_elements.py
@@ -140,6 +140,7 @@ class ConfigElement(object):
     def get_status(self, basepath=None, untracked=False):
         raise NotImplementedError("ConfigElement get_status unimplemented")
 
+
     def backup(self, backup_path):
         if not backup_path:
             raise MultiProjectException(
@@ -397,7 +398,7 @@ class VCSConfigElement(ConfigElement):
                         version=version,
                         tags=self.get_properties())
 
-    def get_versioned_path_spec(self):
+    def get_versioned_path_spec(self, fetch=False):
         "yaml looking up current version"
         version = self.version
         if version == '':
@@ -410,6 +411,8 @@ class VCSConfigElement(ConfigElement):
                 sys.stderr.write("Warning: version '%s' not found for '%s'\n"
                                   % (self.version, self.local_name))
         currevision = self._get_vcsc().get_version()
+        remote_revision = self._get_vcsc().get_remote_version(fetch=fetch)
+        curr_version = self._get_vcsc().get_current_version_label()
         uri = self.uri
         curr_uri = self._get_vcsc().get_url()
         # uri might be a shorthand notation equivalent to curr_uri
@@ -420,8 +423,10 @@ class VCSConfigElement(ConfigElement):
                         scmtype=self.get_vcs_type_name(),
                         uri=self.uri,
                         version=version,
+                        curr_version=curr_version,
                         revision=revision,
                         currevision=currevision,
+                        remote_revision=remote_revision,
                         curr_uri=curr_uri,
                         tags=self.get_properties())
 

--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -323,7 +323,7 @@ def get_path_spec_from_yaml(yaml_dict):
     tags = []
     if type(yaml_dict) != dict:
         raise MultiProjectException(
-            "Yaml for each element must be in YAML dict form")
+            "Yaml for each element must be in YAML dict form: %s " % yaml_dict)
     # old syntax:
 # - hg: {local-name: common_rosdeps,
 #        version: common_rosdeps-1.0.2,

--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -183,9 +183,11 @@ class PathSpec:
                  scmtype=None,
                  uri=None,
                  version=None,
+                 curr_version=None,
                  tags=None,
                  revision=None,
                  currevision=None,
+                 remote_revision=None,
                  path=None,
                  curr_uri=None):
         """
@@ -194,6 +196,7 @@ class PathSpec:
         :param scmtype: one of __ALLTYPES__
         :param uri: uri from config file
         :param version: version label from config file (branchname, tagname, sha-id)
+        :param cur_version: version information label(s) from VCS (branchname, remote, tracking branch)
         :param tags: arbirtrary meta-information (used for ROS package indexing)
         :param revision: unique id of label stored in version
         :param currrevision: unique id of actual version in file system
@@ -205,10 +208,12 @@ class PathSpec:
         self._uri = uri
         self._curr_uri = curr_uri
         self._version = version
+        self._curr_version = curr_version
         self._scmtype = scmtype
         self._tags = tags or []
         self._revision = revision
         self._currevision = currevision
+        self._remote_revision = remote_revision
 
     def __str__(self):
         return str(self.get_legacy_yaml())
@@ -231,8 +236,10 @@ class PathSpec:
             self._scmtype = None
             self._uri = None
             self._version = None
+            self._curr_version = None
             self._revision = None
             self._currevision = None
+            self._remote_revision = None
 
     def get_legacy_type(self):
         """return one of __ALLTYPES__"""
@@ -286,11 +293,17 @@ class PathSpec:
     def get_version(self):
         return self._version
 
+    def get_curr_version(self):
+        return self._curr_version
+
     def get_revision(self):
         return self._revision
 
     def get_current_revision(self):
         return self._currevision
+
+    def get_remote_revision(self):
+        return self._remote_revision
 
     def get_uri(self):
         return self._uri

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -993,6 +993,7 @@ The Status (S) column shows
  x  for missing
  L  for uncommited (local) changes
  V  for difference in version and/or remote URI
+ C  for difference in local and remote versions
 
 The 'Version-Spec' column shows what tag, branch or revision was given
 in the .rosinstall file. The 'UID' column shows the unique ID of the
@@ -1030,6 +1031,10 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
         parser.add_option(
             "--yaml", dest="yaml", default=False,
             help="Shows only version of single entry. Intended for scripting.",
+            action="store_true")
+        parser.add_option(
+            "--fetch", dest="fetch", default=False,
+            help="When used, retrieves version information from remote (takes longer).",
             action="store_true")
         parser.add_option(
             "-u", "--untracked", dest="untracked",
@@ -1081,7 +1086,8 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
         # this call takes long, as it invokes scms.
         outputs = multiproject_cmd.cmd_info(config,
                                             localnames=args,
-                                            untracked=options.untracked)
+                                            untracked=options.untracked,
+                                            fetch=options.fetch)
         if args and len(args) == 1:
             # if only one element selected, print just one line
             print(get_info_list(config.get_base_path(),

--- a/src/wstool/multiproject_cmd.py
+++ b/src/wstool/multiproject_cmd.py
@@ -392,7 +392,7 @@ def cmd_snapshot(config, localnames=None):
     return source_aggregate
 
 
-def cmd_info(config, localnames=None, untracked=False):
+def cmd_info(config, localnames=None, untracked=False, fetch=False):
     """This function compares what should be (config_file) with what is
     (directories) and returns a list of dictionary giving each local
     path and all the state information about it available.
@@ -403,9 +403,10 @@ def cmd_info(config, localnames=None, untracked=False):
         Auxilliary class to perform IO-bound operations in individual threads
         """
 
-        def __init__(self, element, path, untracked):
+        def __init__(self, element, path, untracked, fetch):
             self.element = element
             self.path = path
+            self.fetch = fetch
             self.untracked = untracked
 
         def do_work(self):
@@ -415,8 +416,11 @@ def cmd_info(config, localnames=None, untracked=False):
             curr_uri = None
             exists = False
             version = ""  # what is given in config file
+            curr_version_label = ""  # e.g. branchname
+            remote_revision = "" # UID on remote
+            display_version = ''
             modified = ""
-            actualversion = ""  # revision number of version
+            currevision = ""  # revision number of version
             specversion = ""  # actual revision number
             localname = self.element.get_local_name()
             path = self.element.get_path() or localname
@@ -431,8 +435,15 @@ def cmd_info(config, localnames=None, untracked=False):
                     path_spec = self.element.get_path_spec()
                     version = path_spec.get_version()
                 else:
-                    path_spec = self.element.get_versioned_path_spec()
+                    path_spec = self.element.get_versioned_path_spec(fetch=fetch)
                     version = path_spec.get_version()
+                    remote_revision = path_spec.get_remote_revision()
+                    curr_version_label = path_spec.get_curr_version()
+                    if (curr_version_label is not None and
+                        version != curr_version_label):
+                        display_version = curr_version_label
+                    else:
+                        display_version = version
                     curr_uri = path_spec.get_curr_uri()
                     status = self.element.get_status(self.path, self.untracked)
                     if (status is not None and
@@ -442,9 +453,8 @@ def cmd_info(config, localnames=None, untracked=False):
                     if (version is not None and
                         version.strip() != '' and
                         (specversion is None or specversion.strip() == '')):
-
                         specversion = '"%s"' % version
-                    actualversion = path_spec.get_current_revision()
+                    currevision = path_spec.get_current_revision()
                 scm = path_spec.get_scmtype()
                 uri = path_spec.get_uri()
             return {'scm': scm,
@@ -454,8 +464,10 @@ def cmd_info(config, localnames=None, untracked=False):
                     'uri': uri,
                     'curr_uri': curr_uri,
                     'version': version,
+                    'remote_revision': remote_revision,
+                    'curr_version_label': curr_version_label,
                     'specversion': specversion,
-                    'actualversion': actualversion,
+                    'actualversion': currevision,
                     'modified': modified,
                     'properties': self.element.get_properties()}
 
@@ -466,7 +478,7 @@ def cmd_info(config, localnames=None, untracked=False):
     work = DistributedWork(capacity=len(elements), num_threads=-1)
     for element in elements:
         if element.get_properties() is None or not 'setup-file' in element.get_properties():
-            work.add_thread(InfoRetriever(element, path, untracked))
+            work.add_thread(InfoRetriever(element, path, untracked, fetch))
     outputs = work.run()
 
     return outputs

--- a/test/local/mock_client.py
+++ b/test/local/mock_client.py
@@ -47,7 +47,8 @@ class MockVcsClient():
                  vcs_presence=False,
                  url="mockurl",
                  actualversion=None,
-                 specversion=None):
+                 specversion=None,
+                 remoteversion=None):
         self.scmtype = scmtype
         self.path_exists_flag = path_exists
         self.checkout_success = checkout_success
@@ -58,6 +59,7 @@ class MockVcsClient():
         self.updated = False
         self.actualversion = actualversion
         self.specversion = specversion
+        self.remoteversion = remoteversion
 
     def get_vcs_type_name(self):
         return self.scmtype
@@ -70,6 +72,12 @@ class MockVcsClient():
             return self.actualversion
         else:
             return self.specversion
+
+    def get_remote_version(self, fetch=False):
+        return self.remoteversion
+
+    def get_current_version_label(self):
+        return self.scmtype + "mockcurrentversionlabel"
 
     def get_status(self, basepath=None, untracked=False):
         return self.scmtype + " mockstatus%s,%s" % (basepath, untracked)

--- a/test/local/test_cli.py
+++ b/test/local/test_cli.py
@@ -558,7 +558,7 @@ class GetStatusDiffInfoCmdTest(unittest.TestCase):
                     'localname': 'localname',
                     'specversion': None,
                     'actualversion': None}]
-        self.assertEqual(["localname", "svn", "tags/tagname", "some.svn.tags.server/some/"], _nth_line_split(-1, wstool.cli_common.get_info_table(basepath, entries)))
+        self.assertEqual(["localname", "svn", "version", "(tags/tagname)", "some.svn.tags.server/some/"], _nth_line_split(-1, wstool.cli_common.get_info_table(basepath, entries)))
         entries = [{'scm': 'svn',
                     'uri': 'https://some.svn.tags.server/some/branches/branchname',
                     'curr_uri': None,
@@ -566,7 +566,7 @@ class GetStatusDiffInfoCmdTest(unittest.TestCase):
                     'localname': 'localname',
                     'specversion': None,
                     'actualversion': None}]
-        self.assertEqual(["localname", "svn", "branches/branchname", "some.svn.tags.server/some/"], _nth_line_split(-1, wstool.cli_common.get_info_table(basepath, entries)))
+        self.assertEqual(["localname", "svn", "version", "(branches/branchname)", "some.svn.tags.server/some/"], _nth_line_split(-1, wstool.cli_common.get_info_table(basepath, entries)))
         entries = [{'scm': 'svn',
                     'uri': 'https://some.svn.tags.server/some/trunk',
                     'curr_uri': None,
@@ -574,7 +574,7 @@ class GetStatusDiffInfoCmdTest(unittest.TestCase):
                     'localname': 'localname',
                     'specversion': None,
                     'actualversion': None}]
-        self.assertEqual(["localname", "svn", "trunk", "some.svn.tags.server/some/"], _nth_line_split(-1, wstool.cli_common.get_info_table(basepath, entries)))
+        self.assertEqual(["localname", "svn", "version", "(trunk)", "some.svn.tags.server/some/"], _nth_line_split(-1, wstool.cli_common.get_info_table(basepath, entries)))
         entries = [{'scm': 'svn',
                     'uri': 'https://some.svn.tags.server/some/branches/branchname',
                     'curr_uri': 'https://some.svn.tags.server/some/tags/tagname',

--- a/test/local/test_diff_functions_hg.py
+++ b/test/local/test_diff_functions_hg.py
@@ -221,7 +221,7 @@ class WstoolInfoHgTest(AbstractSCMTest):
         wstool_main(cmd)
         output = output.getvalue()
         tokens = _nth_line_split(-2, output)
-        self.assertEqual(['clone', 'hg', self.version_end, os.path.join(self.test_root_path, 'remote')], tokens, output)
+        self.assertEqual(['clone', 'hg', 'default', '(-)', self.version_end, os.path.join(self.test_root_path, 'remote')], tokens)
 
         clone_path = os.path.join(self.local_path, "clone")
         # make local modifications check
@@ -231,7 +231,7 @@ class WstoolInfoHgTest(AbstractSCMTest):
         wstool_main(cmd)
         output = output.getvalue()
         tokens = _nth_line_split(-2, output)
-        self.assertEqual(['clone', 'M', 'hg', self.version_end, os.path.join(self.test_root_path, 'remote')], tokens)
+        self.assertEqual(['clone', 'M', 'hg', 'default', '(-)', self.version_end, os.path.join(self.test_root_path, 'remote')], tokens)
 
         subprocess.check_call(["rm", ".rosinstall"], cwd=self.local_path)
         _add_to_file(os.path.join(self.local_path, ".rosinstall"), "- other: {local-name: ../ros}\n- hg: {local-name: clone, uri: ../remote, version: \"footag\"}")
@@ -240,7 +240,7 @@ class WstoolInfoHgTest(AbstractSCMTest):
         wstool_main(cmd)
         output = output.getvalue()
         tokens = _nth_line_split(-2, output)
-        self.assertEqual(['clone', 'MV', 'hg', 'footag', self.version_end, "(%s)" % self.version_init, os.path.join(self.test_root_path, 'remote')], tokens)
+        self.assertEqual(['clone', 'MV', 'hg', 'default', '(footag)', self.version_end, "(%s)" % self.version_init, os.path.join(self.test_root_path, 'remote')], tokens)
 
         subprocess.check_call(["rm", "-rf", "clone"], cwd=self.local_path)
         os.chdir(self.test_root_path)
@@ -248,4 +248,4 @@ class WstoolInfoHgTest(AbstractSCMTest):
         wstool_main(cmd)
         output = output.getvalue()
         tokens = _nth_line_split(-2, output)
-        self.assertEqual(['clone', 'x', 'hg', 'footag', os.path.join(self.test_root_path, 'remote')], tokens)
+        self.assertEqual(['clone', 'x', 'hg', '(footag)', os.path.join(self.test_root_path, 'remote')], tokens)

--- a/test/local/test_diff_functions_svn.py
+++ b/test/local/test_diff_functions_svn.py
@@ -261,7 +261,7 @@ class WstoolInfoSvnTest(AbstractSCMTest):
         wstool_main(cmd)
         output = output.getvalue()
         tokens = _nth_line_split(-2, output)
-        self.assertEqual(['clone', 'MV', 'svn', '1', self.version_end, "(%s)" % self.version_init, self.svn_uri], tokens)
+        self.assertEqual(['clone', 'MV', 'svn', '1', '(-)', self.version_end, "(%s)" % self.version_init, self.svn_uri], tokens)
 
         subprocess.check_call(["rm", "-rf", "clone"], cwd=self.local_path)
         os.chdir(self.test_root_path)
@@ -269,4 +269,4 @@ class WstoolInfoSvnTest(AbstractSCMTest):
         wstool_main(cmd)
         output = output.getvalue()
         tokens = _nth_line_split(-2, output)
-        self.assertEqual(['clone', 'x', 'svn', '1', self.svn_uri], tokens)
+        self.assertEqual(['clone', 'x', 'svn', '(-)', self.svn_uri], tokens)

--- a/test/local/test_diff_functions_svn.py
+++ b/test/local/test_diff_functions_svn.py
@@ -115,7 +115,9 @@ Index: clone/modified.txt
 @@ -0,0 +1 @@
 +foo"""]
         for snippet in expected:
-            self.assertTrue(snippet in output, output)
+            for line in snippet.splitlines():
+                # assertIn is not supported in Python2.6
+                self.assertTrue(line in output, output)
 
     def test_wstool_diff_svn_outside(self):
         """Test diff output for svn when run outside workspace"""


### PR DESCRIPTION
This depends on https://github.com/vcstools/vcstools/pull/98 changes being merged and released first

This should supercede #35 which can be closed. 

- [x] test wstool info with diverse circumstances 
- [x] add --fetch option (probably requires another extension to vcstools
- [x]  fix info command for single repository ```wstool info xyz```
