### PR TITLE
Add wstool completion (alternative of #33)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include completion *

--- a/completion/_wstool
+++ b/completion/_wstool
@@ -1,0 +1,40 @@
+#compdef wstool
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2010, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+_wstool () {
+  local e
+  e=$(dirname ${funcsourcetrace[1]%:*})/wstool-completion.bash
+  if [ -f $e ]; then
+    . $e
+  fi
+}

--- a/completion/wstool-completion.bash
+++ b/completion/wstool-completion.bash
@@ -1,0 +1,242 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2010, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Programmable completion for the wstool command under bash. Source
+# this file (or on some systems add it to ~/.bash_completion and start a new
+# shell)
+
+# ZSH support
+if [[ -n ${ZSH_VERSION-} ]]; then
+  autoload -U +X bashcompinit && bashcompinit
+fi
+
+# put here to be extendable
+if [ -z "$WSTOOL_BASE_COMMANDS" ]; then
+  _WSTOOL_BASE_COMMANDS="help init set merge info remove diff status update --version"
+fi
+
+# Based originally on the bzr/svn bash completition scripts.
+_wstool_complete()
+{
+  local cur cmds cmdOpts opt helpCmds optBase i
+
+  COMPREPLY=()
+  cur=${COMP_WORDS[COMP_CWORD]}
+
+  cmds=$_WSTOOL_BASE_COMMANDS
+
+  if [[ $COMP_CWORD -eq 1 ]] ; then
+    COMPREPLY=( $( compgen -W "$cmds" -- $cur ) )
+    return 0
+  fi
+
+  # if not typing an option, or if the previous option required a
+  # parameter, then fallback on ordinary filename expansion
+  helpCmds='help|--help|h|\?'
+  if [[ ${COMP_WORDS[1]} != @@($helpCmds) ]] && \
+     [[ "$cur" != -* ]] ; then
+    case ${COMP_WORDS[1]} in
+    info|diff|di|status|st|remove|rm|update|up)
+      cmdOpts=`wstool info --only=localname 2> /dev/null | sed 's,:, ,g'`
+      COMPREPLY=( $( compgen -W "$cmdOpts" -- $cur ) )
+    ;;
+    set)
+      if [[ $COMP_CWORD -eq 2 ]]; then
+          cmdOpts=`wstool info --only=localname 2> /dev/null | sed 's,:, ,g'`
+          COMPREPLY=( $( compgen -W "$cmdOpts" -- $cur ) )
+      elif [[ $COMP_CWORD -eq 3 ]]; then
+          cmdOpts=`wstool info ${COMP_WORDS[2]} --only=uri 2> /dev/null`
+          COMPREPLY=( $( compgen -W "$cmdOpts" -- $cur ) )
+      else
+          if [[ ${COMP_WORDS[$(( $COMP_CWORD - 1 ))]} == "--version-new" ]]; then
+              cmdOpts=`wstool info ${COMP_WORDS[2]} --only=version 2> /dev/null|sed 's/,$//'`
+              COMPREPLY=( $( compgen -W "$cmdOpts" -- $cur ) )
+          fi
+      fi
+    ;;
+    esac
+    return 0
+  fi
+
+  cmdOpts=
+  case ${COMP_WORDS[1]} in
+  status|st)
+    cmdOpts="-t --target-workspace --untracked"
+    ;;
+  diff|di)
+    cmdOpts="-t --target-workspace"
+    ;;
+  init)
+    cmdOpts="-t --target-workspace --continue-on-error"
+    ;;
+  merge)
+    cmdOpts="-t --target-workspace -y --confirm-all -r --merge-replace -k --merge-keep -a --merge-kill-append"
+    ;;
+  set)
+    cmdOpts="-t --target-workspace --git --svn --bzr --hg --uri -v --version-new --detached -y --confirm"
+    ;;
+  remove|rm)
+    cmdOpts="-t --target-workspace"
+    ;;
+  update|up)
+    cmdOpts="-t --target-workspace  --delete-changed-uris --abort-changed-uris --backup-changed-uris"
+    ;;
+  snapshot)
+    cmdOpts="-t --target-workspace"
+    ;;
+  info)
+    cmdOpts="-t --target-workspace --data-only --no-pkg-path --pkg-path-only --only --yaml"
+    ;;
+  *)
+    ;;
+  esac
+
+  cmdOpts="$cmdOpts --help -h"
+
+  # take out options already given
+  for (( i=2; i<=$COMP_CWORD-1; ++i )) ; do
+    opt=${COMP_WORDS[$i]}
+
+    case $opt in
+    --*)    optBase=${opt/=*/} ;;
+    -*)     optBase=${opt:0:2} ;;
+    esac
+
+    cmdOpts=" $cmdOpts "
+    cmdOpts=${cmdOpts/ ${optBase} / }
+
+    # take out alternatives
+    case $optBase in
+    -h)                 cmdOpts=${cmdOpts/ --help / } ;;
+    --help)             cmdOpts=${cmdOpts/ -h / } ;;
+    -t)                 cmdOpts=${cmdOpts/ --target-workspace / } ;;
+    --target-workspace) cmdOpts=${cmdOpts/ -t / } ;;
+    --delete-changed-uris)
+      cmdOpts=${cmdOpts/ --abort-changed-uris / }
+      cmdOpts=${cmdOpts/ --backup-changed-uris / }
+    ;;
+    --abort-changed-uris)
+      cmdOpts=${cmdOpts/ --delete-changed-uris / }
+      cmdOpts=${cmdOpts/ --backup-changed-uris / }
+    ;;
+    --backup-changed-uris)
+      cmdOpts=${cmdOpts/ --delete-changed-uris / }
+      cmdOpts=${cmdOpts/ --abort-changed-uris  / }
+    ;;
+    # scm options
+    --svn)
+      cmdOpts=${cmdOpts/ --git / }
+      cmdOpts=${cmdOpts/ --hg / }
+      cmdOpts=${cmdOpts/ --bzr / }
+      cmdOpts=${cmdOpts/ --detached / }
+    ;;
+    --git)
+      cmdOpts=${cmdOpts/ --svn / }
+      cmdOpts=${cmdOpts/ --hg / }
+      cmdOpts=${cmdOpts/ --bzr / }
+      cmdOpts=${cmdOpts/ --detached / }
+    ;;
+    --hg)
+      cmdOpts=${cmdOpts/ --git / }
+      cmdOpts=${cmdOpts/ --svn / }
+      cmdOpts=${cmdOpts/ --bzr / }
+      cmdOpts=${cmdOpts/ --detached / }
+    ;;
+    --bzr)
+      cmdOpts=${cmdOpts/ --git / }
+      cmdOpts=${cmdOpts/ --hg / }
+      cmdOpts=${cmdOpts/ --svn / }
+      cmdOpts=${cmdOpts/ --detached / }
+    ;;
+    --detached)
+      cmdOpts=${cmdOpts/ --git / }
+      cmdOpts=${cmdOpts/ --hg / }
+      cmdOpts=${cmdOpts/ --bzr / }
+      cmdOpts=${cmdOpts/ --svn / }
+    ;;
+    # merge options
+    --merge-replace)
+      cmdOpts=${cmdOpts/ --merge-keep / }
+      cmdOpts=${cmdOpts/ --merge-kill-append / }
+      cmdOpts=${cmdOpts/ -r / }
+      cmdOpts=${cmdOpts/ -a / }
+      cmdOpts=${cmdOpts/ -k / }
+    ;;
+    --merge-keep)
+      cmdOpts=${cmdOpts/ --merge-replace / }
+      cmdOpts=${cmdOpts/ --merge-kill-append / }
+      cmdOpts=${cmdOpts/ -r / }
+      cmdOpts=${cmdOpts/ -a / }
+      cmdOpts=${cmdOpts/ -k / }
+    ;;
+    --merge-kill-append)
+      cmdOpts=${cmdOpts/ --merge-keep / }
+      cmdOpts=${cmdOpts/ --merge-replace / }
+      cmdOpts=${cmdOpts/ -r / }
+      cmdOpts=${cmdOpts/ -a / }
+      cmdOpts=${cmdOpts/ -k / }
+    ;;
+    -r)
+      cmdOpts=${cmdOpts/ --merge-keep / }
+      cmdOpts=${cmdOpts/ --merge-kill-append / }
+      cmdOpts=${cmdOpts/ --merge-replace / }
+      cmdOpts=${cmdOpts/ -a / }
+      cmdOpts=${cmdOpts/ -k / }
+    ;;
+    -a)
+      cmdOpts=${cmdOpts/ --merge-keep / }
+      cmdOpts=${cmdOpts/ --merge-kill-append / }
+      cmdOpts=${cmdOpts/ --merge-replace / }
+      cmdOpts=${cmdOpts/ -r / }
+      cmdOpts=${cmdOpts/ -k / }
+    ;;
+    -k)
+      cmdOpts=${cmdOpts/ --merge-keep / }
+      cmdOpts=${cmdOpts/ --merge-kill-append / }
+      cmdOpts=${cmdOpts/ --merge-replace / }
+      cmdOpts=${cmdOpts/ -a / }
+      cmdOpts=${cmdOpts/ -r / }
+    ;;
+    esac
+
+    # skip next option if this one requires a parameter
+    if [[ $opt == @@($optsParam) ]] ; then
+      ((++i))
+    fi
+  done
+
+  COMPREPLY=( $( compgen -W "$cmdOpts" -- $cur ) )
+
+  return 0
+
+}
+complete -F _wstool_complete -o default wstool

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup
 
+import os
+import sys
 import imp
+import argparse
 
 
 def get_version():
@@ -15,10 +18,48 @@ def get_version():
             ver_file.close()
 
 
+def _resolve_prefix(prefix, type):
+    osx_system_prefix = '/System/Library/Frameworks/Python.framework/Versions'
+    if type == 'man':
+        if prefix == '/usr':
+            return '/usr/share'
+        if sys.prefix.startswith(osx_system_prefix):
+            return '/usr/share'
+    elif type == 'bash_comp':
+        if prefix == '/usr':
+            return '/'
+        if sys.prefix.startswith(osx_system_prefix):
+            return '/'
+    elif type == 'zsh_comp':
+        if sys.prefix.startswith(osx_system_prefix):
+            return '/usr'
+    else:
+        raise ValueError('not supported type')
+    return prefix
+
+
+def get_data_files(prefix):
+    data_files = []
+    bash_comp_dest = os.path.join(_resolve_prefix(prefix, 'bash_comp'),
+                                  'etc/bash_completion.d')
+    data_files.append((bash_comp_dest, ['completion/wstool-completion.bash']))
+    zsh_comp_dest = os.path.join(_resolve_prefix(prefix, 'zsh_comp'),
+                                 'share/zsh/site-functions')
+    data_files.append((zsh_comp_dest, ['completion/_wstool']))
+    return data_files
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--prefix', default='',
+                    help='prefix to install data files')
+opts, _ = parser.parse_known_args(sys.argv)
+prefix = opts.prefix
+
 setup(name='wstool',
       version=get_version(),
       packages=['wstool'],
       package_dir={'': 'src'},
+      data_files=get_data_files(prefix),
       # rosinstall dependency to be kept in order not to break ros hydro install instructions
       install_requires=['vcstools>=0.1.34', 'pyyaml'],
       scripts=["scripts/wstool"],


### PR DESCRIPTION
RELATED TO: https://github.com/vcstools/wstool/pull/33

This is another option how to install completion scripts.
Usually the completion scripts are installed to (by setup.py):

* /usr/local/etc/bash_completion.d/wstool-completion.bash
* /usr/local/share/zsh/site-functions/_wstool

and it is not needed to source the completion script manually for zsh users.
as for bash users, they should add some settings to source files in `/usr/local/etc/bash_completion.d`
but the location is easy to find out and I think this is common way in both debian and darwin.

I made change to use `compdef` in zsh completion script to get completion without source it.