### PR TITLE
Add option `--root` to wstool-info to get workspace root path

### DIFF
--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -1006,6 +1006,10 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
 """ % {'prog': self.progname, 'opts': ONLY_OPTION_VALID_ATTRS},
             epilog="See: http://www.ros.org/wiki/rosinstall for details\n")
         parser.add_option(
+            "--root", dest="show_ws_root", default=False,
+            help="Show workspace root path",
+            action="store_true")
+        parser.add_option(
             "--data-only", dest="data_only", default=False,
             help="Does not provide explanations",
             action="store_true")
@@ -1041,6 +1045,10 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
         elif config.get_base_path() != target_path:
             raise MultiProjectException("Config path does not match %s %s " %
                                         (config.get_base_path(), target_path))
+
+        if options.show_ws_root:
+            print(config.get_base_path())
+            return 0
 
         if args == []:
             args = None

--- a/test/local/test_cli.py
+++ b/test/local/test_cli.py
@@ -648,6 +648,12 @@ class MultiprojectCLITest(AbstractFakeRosBasedTest):
         self.assertTrue(os.path.exists(os.path.join(self.local_path, 'gitrepo')))
         self.assertTrue(os.path.exists(os.path.join(self.local_path, 'hgrepo')))
 
+    def test_cmd_info(self):
+        self.local_path = os.path.join(self.test_root_path, "ws_test_cmd_info")
+        cli = MultiprojectCLI(progname='multi_cli',
+                              config_filename='.rosinstall')
+        self.assertEqual(0, cli.cmd_info(self.local_path, ['--root']))
+
     def test_cmd_set(self):
         self.local_path = os.path.join(self.test_root_path, "ws31b")
         cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall')


### PR DESCRIPTION
issue: https://github.com/vcstools/wstool/issues/51
Just print workspace root path with `--root` option for wstool-info