### PR TITLE
fix #67: -j option and default limit of 10 broken, uses maximum instead.

### DIFF
--- a/src/wstool/common.py
+++ b/src/wstool/common.py
@@ -309,7 +309,7 @@ class DistributedWork():
         self.threads = []
         self.sequentializers = {}
         self.index = 0
-        self.num_threads = capacity if num_threads <= 0  else max(num_threads, capacity)
+        self.num_threads = capacity if num_threads <= 0 else min(num_threads, capacity)
         self.silent = silent
 
     def add_thread(self, worker):

--- a/test/local/test_multiproject_functions.py
+++ b/test/local/test_multiproject_functions.py
@@ -187,6 +187,16 @@ class FunctionsTest(unittest.TestCase):
         self.assertEqual(thing.done, True, result)
         self.assertEqual(False, 'error' in result[0], result)
 
+    def test_distributed_work_init(self):
+        work = DistributedWork(capacity=200)
+        self.assertEqual(10, work.num_threads)
+        work = DistributedWork(capacity=3, num_threads=5)
+        self.assertEqual(3, work.num_threads)
+        work = DistributedWork(capacity=5, num_threads=3)
+        self.assertEqual(3, work.num_threads)
+        work = DistributedWork(capacity=3, num_threads=-1)
+        self.assertEqual(3, work.num_threads)
+
     def test_distributed_work(self):
         work = DistributedWork(3)
 


### PR DESCRIPTION
@wjwwood: Sorry about this, just mixed up min and max in my head and did not bother to test since it looked simple.