### PR TITLE
Stop creating new file for soft linked config file

### DIFF
--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -384,7 +384,8 @@ def generate_config_yaml(config, filename, header, pretty=False,
     """
     if not os.path.exists(config.get_base_path()):
         os.makedirs(config.get_base_path())
-    with open(os.path.join(config.get_base_path(), filename), 'w+b') as f:
+    config_filepath = os.path.realpath(os.path.join(config.get_base_path(), filename))
+    with open(config_filepath, 'w+b') as f:
         if header is not None:
             f.write(header.encode('UTF-8'))
         if sort_with_localname:

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -579,7 +579,7 @@ $ roslocate info robot_model | %(prog)s merge -
         if newconfig is not None:
             print("Config changed, maybe you need run %s update to update SCM entries." % self.progname)
             print("Overwriting %s" % os.path.join(newconfig.get_base_path(), self.config_filename))
-            shutil.move(os.path.join(newconfig.get_base_path(), self.config_filename), "%s.bak" % os.path.join(newconfig.get_base_path(), self.config_filename))
+            shutil.copy(os.path.join(newconfig.get_base_path(), self.config_filename), "%s.bak" % os.path.join(newconfig.get_base_path(), self.config_filename))
             self.config_generator(newconfig, self.config_filename, get_header(self.progname))
             print("\nupdate complete.")
         else:
@@ -940,7 +940,7 @@ $ %(progname)s set robot_model --version-new robot_model-1.7.1
         if newconfig is not None:
             print("Overwriting %s" % os.path.join(
                 newconfig.get_base_path(), self.config_filename))
-            shutil.move(
+            shutil.copy(
                 os.path.join(newconfig.get_base_path(), self.config_filename),
                 "%s.bak" % os.path.join(newconfig.get_base_path(), self.config_filename))
             self.config_generator(newconfig, self.config_filename)
@@ -1074,7 +1074,7 @@ The command removes entries from your configuration file, it does not affect you
         if success:
             print("Overwriting %s" % os.path.join(config.get_base_path(),
                                                   self.config_filename))
-            shutil.move(os.path.join(config.get_base_path(),
+            shutil.copy(os.path.join(config.get_base_path(),
                                      self.config_filename),
                         "%s.bak" % os.path.join(config.get_base_path(),
                                                 self.config_filename))


### PR DESCRIPTION
Closes #58

* just copy .rosinstall to .rosinstall.bak (so .rosinstall.bak is not soft link)
* edit realpath of .rosinstall (it does not break soft link)