### PR TITLE
Add --unmanaged option to set, to add all unmanaged elements

### DIFF
--- a/src/wstool/cli_common.py
+++ b/src/wstool/cli_common.py
@@ -172,7 +172,7 @@ def _get_status_flags(basepath, elt_dict):
     return mflag
 
 
-def get_info_table_elements(basepath, entries):
+def get_info_table_elements(basepath, entries, unmanaged):
     """returns a list of dict with refined information from entries"""
 
     outputs = []
@@ -236,7 +236,7 @@ def get_info_table_elements(basepath, entries):
                 output_dict['matching'] = line['actualversion']
 
             common_prefixes = ["https://", "http://"]
-            if line['uri'] is not None:
+            if line['uri'] is not None and unmanaged is False:
                 for pre in common_prefixes:
                     if line['uri'].startswith(pre):
                         line['uri'] = line['uri'][len(pre):]
@@ -291,7 +291,8 @@ def get_info_table(basepath, entries, data_only=False, reverse=False, unmanaged=
 
     outputs = get_info_table_elements(
         basepath=basepath,
-        entries=entries)
+        entries=entries,
+        unmanaged=unmanaged)
 
     # adjust column width
     column_length = {}

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -816,6 +816,9 @@ $ %(progname)s set robot_model --version-new robot_model-1.7.1
         parser.add_option("-u", "--update", dest="do_update", default=False,
                           help="update repository after set",
                           action="store_true")
+        parser.add_option("--unmanaged", dest="unmanaged", default=False,
+                          help="Set unmanaged elements",
+                          action="store_true")
         # -t option required here for help but used one layer above, see cli_common
         parser.add_option(
             "-t", "--target-workspace", dest="workspace", default=None,
@@ -839,6 +842,20 @@ $ %(progname)s set robot_model --version-new robot_model-1.7.1
             raise MultiProjectException(
                 "Config path does not match %s %s " % (config.get_base_path(),
                                                        target_path))
+
+        if options.unmanaged:
+            outputs2 = multiproject_cmd.cmd_find_unmanaged_repos(config)
+            table2 = get_info_table(config.get_base_path(),
+                                   outputs2,
+                                   data_only=True,
+                                   unmanaged=True)
+            for line in table2.splitlines():
+                if options.confirm:
+                    line += " -y"
+                if options.do_update:
+                    line += " -u"
+                self.cmd_set(target_path, line.split())
+            return 0
 
         scmtype = None
         count_scms = 0


### PR DESCRIPTION
I do not found a way to add all unmanaged elements in the workspace at once.
I added the option --unmanaged to "wstool set".

I think it is an interesting feature when you have an initial workspace with multiple repo and you want to start using wstool.