### PR TITLE
fix #71: `wstool info --fetch` shows default git branch 

### DIFF
--- a/src/wstool/cli_common.py
+++ b/src/wstool/cli_common.py
@@ -162,12 +162,18 @@ def _get_status_flags(basepath, elt_dict):
          elt_dict['actualversion'] is not None and
          elt_dict['specversion'] != elt_dict['actualversion'])):
         mflag += 'V'
-    if ('remote_revision' in elt_dict and
-        elt_dict['remote_revision'] != '' and
-        elt_dict['remote_revision'] is not None and
-        elt_dict['actualversion'] is not None and
-        'actualversion' in elt_dict and
-        elt_dict['remote_revision'] != elt_dict['actualversion']):
+    if (('remote_revision' in elt_dict and
+         elt_dict['remote_revision'] != '' and
+         elt_dict['remote_revision'] is not None and
+         elt_dict['actualversion'] is not None and
+         'actualversion' in elt_dict and
+         elt_dict['remote_revision'] != elt_dict['actualversion']) or
+        (('version' not in elt_dict or
+          elt_dict['version'] is None) and
+         'default_remote_label' in elt_dict and
+         elt_dict['default_remote_label'] is not None and
+         ('curr_version' not in elt_dict or
+          elt_dict['curr_version'] != elt_dict['default_remote_label']))):
         mflag += 'C'
     return mflag
 
@@ -225,8 +231,17 @@ def get_info_table_elements(basepath, entries):
             if line['curr_version'] is not None:
                 output_dict['version'] = line['curr_version']
             if output_dict['version'] is not None:
-                if (line['version'] != output_dict['version']):
-                    output_dict['version'] += "  (%s)" % (line['version'] or '-')
+                if line['version'] != output_dict['version']:
+                    if line['version']:
+                        output_dict['version'] += "  (%s)" % line['version']
+                    else:
+                        if line['default_remote_label']:
+                            if output_dict['version'] == line['default_remote_label']:
+                                output_dict['version'] += "  (=)"
+                            else:
+                                output_dict['version'] += "  (%s)" % line['default_remote_label']
+                        else:
+                            output_dict['version'] += "  (-)"
 
             if (line['specversion'] is not None and
                 line['specversion'] != '' and

--- a/src/wstool/config_elements.py
+++ b/src/wstool/config_elements.py
@@ -430,6 +430,12 @@ class VCSConfigElement(ConfigElement):
                         curr_uri=curr_uri,
                         tags=self.get_properties())
 
+    def get_default_remote_label(self):
+        """
+        check remote for e.g. default git branch
+        """
+        return self._get_vcsc().get_default_remote_version_label()
+
     def get_diff(self, basepath=None):
         return self._get_vcsc().get_diff(basepath)
 

--- a/src/wstool/multiproject_cmd.py
+++ b/src/wstool/multiproject_cmd.py
@@ -452,6 +452,7 @@ def cmd_info(config, localnames=None, untracked=False, fetch=False):
             version = ""  # what is given in config file
             curr_version_label = ""  # e.g. branchname
             remote_revision = "" # UID on remote
+            default_remote_label = None # git default branch
             display_version = ''
             modified = ""
             currevision = ""  # revision number of version
@@ -488,6 +489,9 @@ def cmd_info(config, localnames=None, untracked=False, fetch=False):
                         version.strip() != '' and
                         (specversion is None or specversion.strip() == '')):
                         specversion = '"%s"' % version
+                    if (self.fetch and specversion == None and
+                        path_spec.get_scmtype() == 'git'):
+                        default_remote_label = self.element.get_default_remote_label()
                     currevision = path_spec.get_current_revision()
                 scm = path_spec.get_scmtype()
                 uri = path_spec.get_uri()
@@ -499,6 +503,7 @@ def cmd_info(config, localnames=None, untracked=False, fetch=False):
                     'curr_uri': curr_uri,
                     'version': version,
                     'remote_revision': remote_revision,
+                    'default_remote_label': default_remote_label,
                     'curr_version_label': curr_version_label,
                     'specversion': specversion,
                     'actualversion': currevision,


### PR DESCRIPTION
Requires https://github.com/vcstools/vcstools/pull/107