### PR TITLE
add  option to  to pass arg validation

### DIFF
--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -1238,6 +1238,11 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
         parser.add_option("-y", "--confirm", dest="confirm", default='',
                           help="Do not ask for confirmation",
                           action="store_true")
+        # -t option required here for help but used one layer above, see cli_common
+        parser.add_option(
+            "-t", "--target-workspace", dest="workspace", default=None,
+            help="which workspace to use",
+            action="store")
         (options, args) = parser.parse_args(argv)
 
         if config is None:


### PR DESCRIPTION
I found that I needed to have this to use `wstool scrape` with `-t`. I'm not sure why I missed this before. It seems to be the case (that this snippet is required) for other commands too.