### PR TITLE
Added Ubuntu Wily (15.10) and Xenial (16.04)

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 
 Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38)
 Conflicts: python3-wstool
 Conflicts3: python-wstool
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wheezy jessie
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial wheezy jessie
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Added Ubuntu Wily (15.10) and Xenial (16.04) to the list of supported platforms.