### PR TITLE
Fix for issue #89: Invalid options cause wstool to exit with error

### DIFF
--- a/src/wstool/cli_common.py
+++ b/src/wstool/cli_common.py
@@ -413,8 +413,8 @@ def get_info_table_raw_csv(config, properties, localnames):
     lookup_required = False
     for attr in properties:
         if not attr in ONLY_OPTION_VALID_ATTRS:
-            parser.error("Invalid --only option '%s', valids are %s" %
-                         (attr, ONLY_OPTION_VALID_ATTRS))
+            OptionParser().error("Invalid --only option '%s', valids are %s" %
+                                 (attr, ONLY_OPTION_VALID_ATTRS))
         if attr in ['cur_revision', 'cur_uri', 'revision']:
             lookup_required = True
     elements = select_elements(config, localnames)

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -1204,6 +1204,10 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
             only_options = options.only.split(",")
             if only_options == '':
                 parser.error('No valid options given')
+            for attr in only_options:
+                if attr not in ONLY_OPTION_VALID_ATTRS:
+                    parser.error("Invalid --only option '%s', valids are %s" %
+                                 (attr, ONLY_OPTION_VALID_ATTRS))
             lines = get_info_table_raw_csv(config,
                                            properties=only_options,
                                            localnames=args)


### PR DESCRIPTION
This commit fixes issue #89. 

The problem was, that the options are checked, in a function where the parser object doesn't exist.
I have left the check there for now but create a new Parser object, in case the function get's used somewhere else as well. 

But additionally I have inserted a check upstream in the `cmd_info` function. This catches the error and exits cleanly.