### PR TITLE
[WIP] Display version correctly in `info --only`

### DIFF
--- a/src/wstool/cli_common.py
+++ b/src/wstool/cli_common.py
@@ -41,7 +41,7 @@ import re
 from optparse import OptionParser
 from wstool.common import samefile, MultiProjectException, select_elements
 
-ONLY_OPTION_VALID_ATTRS = ['path', 'localname', 'version',
+ONLY_OPTION_VALID_ATTRS = ['path', 'localname', 'version', 'cur_version',
                            'revision', 'cur_revision', 'uri', 'cur_uri', 'scmtype']
 
 
@@ -415,7 +415,7 @@ def get_info_table_raw_csv(config, properties, localnames):
         if not attr in ONLY_OPTION_VALID_ATTRS:
             OptionParser().error("Invalid --only option '%s', valids are %s" %
                                  (attr, ONLY_OPTION_VALID_ATTRS))
-        if attr in ['cur_revision', 'cur_uri', 'revision']:
+        if attr in ['cur_revision', 'cur_uri', 'revision', 'cur_version']:
             lookup_required = True
     elements = select_elements(config, localnames)
     result=[]
@@ -436,6 +436,8 @@ def get_info_table_raw_csv(config, properties, localnames):
                 output.append(spec.get_uri() or '')
             if 'version' == attr:
                 output.append(spec.get_version() or '')
+            if 'cur_version' == attr:
+                output.append(spec.get_curr_version() or '')
             if 'revision' == attr:
                 output.append(spec.get_revision() or '')
             if 'cur_uri' == attr:

--- a/src/wstool/cli_common.py
+++ b/src/wstool/cli_common.py
@@ -413,8 +413,8 @@ def get_info_table_raw_csv(config, properties, localnames):
     lookup_required = False
     for attr in properties:
         if not attr in ONLY_OPTION_VALID_ATTRS:
-            parser.error("Invalid --only option '%s', valids are %s" %
-                         (attr, ONLY_OPTION_VALID_ATTRS))
+            OptionParser().error("Invalid --only option '%s', valids are %s" %
+                                 (attr, ONLY_OPTION_VALID_ATTRS))
         if attr in ['cur_revision', 'cur_uri', 'revision']:
             lookup_required = True
     elements = select_elements(config, localnames)

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -1204,6 +1204,10 @@ $ %(prog)s info --only=path,cur_uri,cur_revision robot_model geometry
             only_options = options.only.split(",")
             if only_options == '':
                 parser.error('No valid options given')
+            for attr in only_options:
+                if attr not in ONLY_OPTION_VALID_ATTRS:
+                    parser.error("Invalid --only option '%s', valids are %s" %
+                                 (attr, ONLY_OPTION_VALID_ATTRS))
             lines = get_info_table_raw_csv(config,
                                            properties=only_options,
                                            localnames=args)


### PR DESCRIPTION
This is a proposal for #91.

I'm not sure what the other options actually are or where the difference between revision and cur_revision is. Therefor I have added a new option `cur_version` to the command. Otherwise of course, we can just change the behaviour of the existing `version` option.
