### PR TITLE
Fixed linux install prefixes and --untracked option handling

### DIFF
--- a/doc/wstool_usage.rst
+++ b/doc/wstool_usage.rst
@@ -247,7 +247,7 @@ columns meanings are as the respective SCM defines them.
 
   Options:
     -h, --help            show this help message and exit
-    --untracked           Also shows untracked files
+    -u, --untracked           Also shows untracked files
     -t WORKSPACE, --target-workspace=WORKSPACE
                           which workspace to use
 
@@ -262,6 +262,5 @@ print a diff over some SCM controlled entries
 
   Options:
     -h, --help            show this help message and exit
-    --untracked           Also shows untracked files
     -t WORKSPACE, --target-workspace=WORKSPACE
                         which workspace to use

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,10 @@ def get_data_files(prefix):
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--prefix', default='',
+parser.add_argument('--prefix', default=None,
                     help='prefix to install data files')
 opts, _ = parser.parse_known_args(sys.argv)
-prefix = opts.prefix
+prefix = opts.prefix or sys.prefix
 
 data_files = get_data_files(prefix)
 

--- a/src/wstool/multiproject_cli.py
+++ b/src/wstool/multiproject_cli.py
@@ -755,7 +755,7 @@ $ %(progname)s foreach --git 'git status'
                               description=__MULTIPRO_CMD_DICT__["status"] +
                               ". The status columns meanings are as the respective SCM defines them.",
                               epilog="""See: http://www.ros.org/wiki/rosinstall for details""")
-        parser.add_option("--untracked", dest="untracked",
+        parser.add_option("-u", "--untracked", dest="untracked",
                           default=False,
                           help="Also shows untracked files",
                           action="store_true")


### PR DESCRIPTION
See the commit messages for more information.  This has been tested on Ubuntu Trusty, and these changes are pretty trivial except for the install prefix change, which shouldn't break on other versions of linux and shouldn't affect other platforms as far as I know.