### PR TITLE
Follow symlinks when finding unmanaged repos

### DIFF
--- a/src/wstool/multiproject_cmd.py
+++ b/src/wstool/multiproject_cmd.py
@@ -579,7 +579,7 @@ def cmd_find_unmanaged_repos(config):
     managed_paths = [os.path.join(path, e.get_local_name()) for e in elements]
     unmanaged_paths = []
     scm_clients = {SvnClient: 'svn', GitClient: 'git', BzrClient:'bzr', HgClient:'hg'}
-    for root, dirs, files in os.walk(path):
+    for root, dirs, files in os.walk(path, followlinks=True):
         if root in managed_paths:
             # remove it from the walk if it's managed
             del dirs[:]


### PR DESCRIPTION
I found this helpful for one of my use cases that involves a workspace containing symlinks to repos.

The resultant yaml file contains paths from the symlinks as local names, for example:
```
- git:
    local-name: path/to/repo
    uri: https://myrepository.git
```

`wstool update` works as expected.