### PR TITLE
Enforce that version is a string to prevent exceptions in the case of an all-integer version ID

### DIFF
--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -378,7 +378,10 @@ def get_path_spec_from_yaml(yaml_dict):
             elif key == "uri":
                 uri = value
             elif key == "version":
-                version = str(value)
+                if value is not None: 
+                    version = str(value)
+                else: 
+                    version = value
             else:
                 raise MultiProjectException(
                     "Unknown key %s in %s" % (key, yaml_dict))

--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -378,7 +378,7 @@ def get_path_spec_from_yaml(yaml_dict):
             elif key == "uri":
                 uri = value
             elif key == "version":
-                version = value
+                version = str(value)
             else:
                 raise MultiProjectException(
                     "Unknown key %s in %s" % (key, yaml_dict))

--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -378,10 +378,11 @@ def get_path_spec_from_yaml(yaml_dict):
             elif key == "uri":
                 uri = value
             elif key == "version":
+                # VCs tools expects version to be
+                # string; otherwise, all integer
+                # versions will break application
                 if value is not None: 
                     version = str(value)
-                else: 
-                    version = value
             else:
                 raise MultiProjectException(
                     "Unknown key %s in %s" % (key, yaml_dict))

--- a/test/local/test_config_yaml.py
+++ b/test/local/test_config_yaml.py
@@ -336,7 +336,7 @@ class ConfigElementYamlWrapper_Test(unittest.TestCase):
         wrap = get_path_spec_from_yaml(struct)
         self.assertEqual(scmtype, wrap.get_scmtype())
         self.assertEqual(scmtype, wrap.get_legacy_type())
-        self.assertTrue(isinstance(wrap.get_version(), str))
+        self.assertIsInstance(wrap.get_version(), str)
         self.assertEqual(uri, wrap.get_uri())
         self.assertEqual(expected_struct, wrap.get_legacy_yaml())
 

--- a/test/local/test_config_yaml.py
+++ b/test/local/test_config_yaml.py
@@ -326,6 +326,20 @@ class ConfigElementYamlWrapper_Test(unittest.TestCase):
         self.assertEqual(uri, wrap.get_uri())
         self.assertEqual({scmtype: {'local-name': local_name, 'uri': uri}}, wrap.get_legacy_yaml())
 
+        # version is a number
+        local_name = 'common_rosdeps'
+        version = 1234
+        uri = 'https://kforge.ros.org/common/rosdepcore'
+        scmtype = 'hg'
+        struct = {scmtype: {'local-name': local_name, 'version': version, 'uri': uri}}
+        expected_struct = {scmtype: {'local-name': local_name, 'version': str(version), 'uri': uri}}
+        wrap = get_path_spec_from_yaml(struct)
+        self.assertEqual(scmtype, wrap.get_scmtype())
+        self.assertEqual(scmtype, wrap.get_legacy_type())
+        self.assertTrue(isinstance(wrap.get_version(), str))
+        self.assertEqual(uri, wrap.get_uri())
+        self.assertEqual(expected_struct, wrap.get_legacy_yaml())
+
         # no version
         local_name = 'common_rosdeps'
         version = None


### PR DESCRIPTION
If, in your workspace, you specify a specific version and the version id happens to contain all numbers, `yaml.load(stream)` will return the value as an integer in the resulting dictionary (see [here](https://github.com/vcstools/wstool/blob/master/src/wstool/config_yaml.py#L74)). 

This is an issue when you are using the `wstool info` command, as its `InfoRetriever` class attempts to build a path spec. However, the `get_versioned_path_spec` ([here](https://github.com/vcstools/wstool/blob/master/src/wstool/config_elements.py#L408)) calls `revision = self._get_vcsc().get_version(self.version)` on line 416, which is in the `vcstools` package. This function ([here](https://github.com/vcstools/vcstools/blob/master/src/vcstools/git.py#L403)) uses the vcstools utility `sanitize` on line 415, which is expecting the input to be a string (see line 198 [here](https://github.com/vcstools/vcstools/blob/master/src/vcstools/common.py#L198)). 

However, since the PyYaml (version 3.12 on my system, Ubuntu-Gnome) returns the version as an integer, this results in an exception. The stack trace is as follows: 
```
Traceback (most recent call last):
 File “/usr/lib/python2.7/dist-packages/wstool/common.py”, line 283, in run
   result_dict = self.worker.do_work()
 File “/usr/lib/python2.7/dist-packages/wstool/multiproject_cmd.py”, line 495, in do_work
   path_spec = self.element.get_versioned_path_spec(fetch=fetch)
 File “/usr/lib/python2.7/dist-packages/wstool/config_elements.py”, line 416, in get_versioned_path_spec
   revision = self._get_vcsc().get_version(self.version)
 File “/usr/lib/python2.7/dist-packages/vcstools/git.py”, line 415, in get_version
   command += ” %s” % sanitized(spec)
 File “/usr/lib/python2.7/dist-packages/vcstools/common.py”, line 198, in sanitized
   if arg is None or arg.strip() == ‘’:
AttributeError: ‘int’ object has no attribute ‘strip’
ERROR in config: Error processing ‘mpl_ros’ : ‘int’ object has no attribute ‘strip’
```
My fix enforces that the version is returned as the expected type, a string. 