### PR TITLE
Added Loader=yaml.FullLoader argument to yaml.load function due to deprecation

### DIFF
--- a/src/wstool/config_yaml.py
+++ b/src/wstool/config_yaml.py
@@ -71,7 +71,7 @@ def get_yaml_from_uri(uri):
         if not stream:
             raise MultiProjectException("couldn't load config uri %s" % uri)
         try:
-            yamldata = yaml.safe_load(stream)
+            yamldata = yaml.safe_load(stream, Loader=yaml.FullLoader)
         except yaml.YAMLError as yame:
             raise MultiProjectException(
                 "Invalid multiproject yaml format in [%s]: %s" % (uri, yame))


### PR DESCRIPTION
See: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation