### PR TITLE
Test with 3.7 and 3.8 Python on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 # Add test requirements; travis will do the rest
 before_install:


### PR DESCRIPTION
This PR just adds configuration to run tests using Python 3.7 and 3.8 on Travis-ci.